### PR TITLE
Remove heroku references to squash error about missing env var

### DIFF
--- a/external-scripts.json
+++ b/external-scripts.json
@@ -1,7 +1,6 @@
 [
   "hubot-diagnostics",
   "hubot-help",
-  "hubot-heroku-keepalive",
   "hubot-google-images",
   "hubot-google-translate",
   "hubot-pugme",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "hubot-google-images": "^0.2.6",
     "hubot-google-translate": "^0.2.0",
     "hubot-help": "^0.1.3",
-    "hubot-heroku-keepalive": "^1.0.2",
     "hubot-maps": "0.0.2",
     "hubot-pugme": "^0.1.0",
     "hubot-redis-brain": "0.0.3",


### PR DESCRIPTION
This silences:

`[Wed Mar 23 2016 11:10:08 GMT-0700 (PDT)] ERROR hubot-heroku-alive included, but missing HUBOT_HEROKU_KEEPALIVE_URL. `heroku config:set HUBOT_HEROKU_KEEPALIVE_URL=$(heroku apps:info -s  | grep web-url | cut -d= -f2)``
